### PR TITLE
Change non-C++ gcc warnings to no

### DIFF
--- a/warnings.md
+++ b/warnings.md
@@ -50,7 +50,7 @@ layout-changed                        | *no*         | *no*             | C4371 
 missing-braces                        | *same*       | *same*           | *no*  |
 missing-field-initializers            | *same*       | *same*           | *no*  |
 missing-noreturn                      | *same*       | *same*           | *no*  |
-missing-prototypes                    | *same*       | *same*           | *no*  |
+missing-prototypes                    | *same*       | *no*             | *no*  |
 name-length-exceeded                  | *no*         | *no*             | C4503 |
 newline-eof                           | *same*       | *no*             | *no*  |
 no-such-warning                       | *no*         | *no*             | C4619 |
@@ -62,7 +62,7 @@ overloaded-virtual                    | *same*       | *same*           | *no*  
 padded                                | *same*       | *same*           | C4820 |
 parentheses                           | *same*       | *same*           | *no*  |
 pedantic                              | *same*       | *same*           | *no*  |
-pointer-sign                          | *same*       | *same*           | *no*  |
+pointer-sign                          | *same*       | *no*             | *no*  |
 return-type                           | *same*       | *same*           | *no*  |
 shadow                                | *same*       | *same*           | *no*  |
 shift-sign-overflow                   | *same*       | *no*             | *no*  |


### PR DESCRIPTION
I used the script below to identify these warnings. It is intended to be run with e.g. <https://github.com/Barro/compiler-warnings/blob/master/gcc/warnings-gcc-7.txt> and <https://github.com/petersteneteg/warn/blob/master/warnings.md> as arguments.

```sh
#!/bin/sh
set -euC

barro_warnings_gcc="$1"
petersteneteg_warnings="$2"

is_non_cxx() {
    g++ -x c++ -E -W"$1" - < "/dev/null" 2>&1 > "/dev/null" | grep -q "warning"
}

is_used() {
    line="$(grep "$1 " "$petersteneteg_warnings")"
    [ -n "$line" ] \
        && printf "%s" "$line" | grep -qv '^[^|]\+|[^|]\+| *\*no\* *|[^|]\+|$'
}

< "$barro_warnings_gcc" \
    sed -n 's/^-W\([a-zA-Z0-9-]\+\).*/\1/p' | \
    while read warning ; do
        if is_non_cxx "$warning" && is_used "$warning" ; then
            echo "$warning"
        fi
    done
```

Documentation for verification:

-   [missing-prototypes](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wmissing-prototypes)
-   [pointer-sign](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wpointer-sign)

Note: if one runs <https://github.com/petersteneteg/warn/blob/master/warn.py> to generate the output `warnings.md`, it now has `*no*` for all the supported compilers for these warnings. This is weird because the source <https://github.com/petersteneteg/warn/blob/master/warnings.md> does not (it's `*same*` for `clang`). This is true for other warnings (not affected by this change) as well:

-   `disabled-macro-expansion`
-   `shift-sign-overflow`
-   `this-used-in-init`
-   `weak-vtables`

I'm not sure if this is a bug.